### PR TITLE
Fix Data Race Issue and Add Fully Buffered Benchmark Case

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -43,11 +43,21 @@ func (chunk *Chunk) Output() chan interface{} {
 }
 
 func (chunk *Chunk) activate() {
+	chunk.mutex.Lock()
+	defer chunk.mutex.Unlock()
 	chunk.isActive = true
 }
 
 func (chunk *Chunk) deactivate() {
+	chunk.mutex.Lock()
+	defer chunk.mutex.Unlock()
 	chunk.isActive = false
+}
+
+func (chunk *Chunk) getIsactivateStatus() bool {
+	chunk.mutex.Lock()
+	defer chunk.mutex.Unlock()
+	return chunk.isActive
 }
 
 func (chunk *Chunk) close() {
@@ -68,7 +78,6 @@ func (chunk *Chunk) receiver() {
 	for {
 		select {
 		case data := <-chunk.incoming:
-
 			// Process data from queue of chunk
 			chunk.handle(data)
 		case <-chunk.closed:

--- a/parallel_chunked_flow.go
+++ b/parallel_chunked_flow.go
@@ -87,6 +87,8 @@ func (pcf *ParallelChunkedFlow) dataReceiver() {
 			pcf.dispatch(data)
 		case <-pcf.closedDataReceiver:
 			return
+		case <-time.After(time.Millisecond):
+			continue
 		}
 	}
 }
@@ -104,7 +106,8 @@ func (pcf *ParallelChunkedFlow) dataExporter() {
 		for {
 
 			// This chunk is empty and not activated, so switching to the next
-			if !chunk.isActive && chunk.isEmpty() {
+			//if !chunk.isActive && chunk.isEmpty() {
+			if !chunk.getIsactivateStatus() && chunk.isEmpty() {
 				break
 			}
 
@@ -116,7 +119,7 @@ func (pcf *ParallelChunkedFlow) dataExporter() {
 				chunk.ack()
 			case <-pcf.closedDataExporter:
 				return
-			case <-time.After(time.Second):
+			case <-time.After(time.Millisecond):
 				continue
 			}
 		}


### PR DESCRIPTION
This PR improves the stability of parallel processing and provides additional performance tests for different load scenarios.

Description:
- Fixed a data race issue detected in the BenchmarkChunkedFlowWithLowChunkCount test, which occurred during concurrent access to shared resources without proper synchronization.
- Added a new benchmark test case to simulate a Fully Buffered scenario. This tests how flow.Push behaves when the internal buffer is full, ensuring stability under high load conditions.
- Used go test -race to detect data race conditions and ensure data integrity in a multi-goroutine environment.

`go clean -testcache && go test -race -bench=BenchmarkChunkedFlowWithLowChunkCount
goos: linux
goarch: amd64
pkg: github.com/cfsghost/parallel-chunked-flow
cpu: Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz
BenchmarkChunkedFlowWithLowChunkCount/Small-4         	  136564	      7521 ns/op
BenchmarkChunkedFlowWithLowChunkCount/Large-4         	    1040	   1122607 ns/op
PASS
ok  	github.com/cfsghost/parallel-chunked-flow	4.225s`

`go clean -testcache && go test -race -bench=BenchmarkChunkedFlowWithLowBufferSize
goos: linux
goarch: amd64
pkg: github.com/cfsghost/parallel-chunked-flow
cpu: Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz
BenchmarkChunkedFlowWithLowBufferSize/FullyBuffer-4         	  140758	      9143 ns/op
PASS
ok  	github.com/cfsghost/parallel-chunked-flow	2.395s`